### PR TITLE
Named fail handlers fixed for multi-transition events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - None right now
 
+## [0.2.1] - 2022-03-05
+
+- Fixed bug where named fail handlers were not called properly for multi-transition events.
+
 ## [0.2.0] - 2022-03-01
 
 - *Breaks API* (sorry!)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simply_fsm (0.1.1)
+    simply_fsm (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/simply_fsm/version.rb
+++ b/lib/simply_fsm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimplyFSM
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/unit/multi_transition_fail_events_spec.rb
+++ b/spec/unit/multi_transition_fail_events_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class MultiTransitionFailHandlingStateMachine
+  class Error < StandardError; end
+  class RunError < StandardError; end
+
+  include SimplyFSM
+
+  state_machine :activity, fail: :on_any_fail do
+    state :sleeping, initial: true
+    state :running
+    state :cleaning
+
+    event :run,
+          fail: ->(_event) { raise RunError, "Cannot run" },
+          transitions: [{ from: :sleeping, to: :running }]
+
+    event :clean, transitions: [
+      { from: :running, to: :cleaning }
+    ]
+
+    event :sleep, transitions: [
+      { from: :running, to: :sleeping },
+      { when: -> { cleaning? }, to: :sleeping }
+    ]
+  end
+
+  def on_any_fail(event_name)
+    raise Error, "Cannot do: #{event_name}"
+  end
+end
+
+RSpec.describe MultiTransitionFailHandlingStateMachine do
+  describe "#sleep" do
+    it "error if already sleeping" do
+      expect { subject.sleep }.to raise_error(MultiTransitionFailHandlingStateMachine::Error)
+    end
+  end
+
+  describe "#run" do
+    it "custom error if already running" do
+      subject.run
+      expect { subject.run }.to raise_error(MultiTransitionFailHandlingStateMachine::RunError)
+    end
+
+    it "custom error if cleaning" do
+      subject.run
+      subject.clean
+      expect { subject.run }.to raise_error(MultiTransitionFailHandlingStateMachine::RunError)
+    end
+  end
+
+  describe "#clean" do
+    it "error if sleeping" do
+      expect { subject.clean }.to raise_error(MultiTransitionFailHandlingStateMachine::Error)
+    end
+
+    it "error if already cleaning" do
+      subject.run
+      subject.clean
+      expect { subject.clean }.to raise_error(MultiTransitionFailHandlingStateMachine::Error)
+    end
+  end
+end


### PR DESCRIPTION
Fixed bug where named fail handlers were not called properly for multi-transition events.